### PR TITLE
Create portfolio project detail pages

### DIFF
--- a/css/projects.css
+++ b/css/projects.css
@@ -1,0 +1,290 @@
+:root {
+    --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --text-primary: #f8fafc;
+    --text-secondary: rgba(248, 250, 252, 0.72);
+    --surface: rgba(15, 23, 42, 0.62);
+    --surface-soft: rgba(15, 23, 42, 0.4);
+    --border: rgba(148, 163, 184, 0.16);
+    --accent: #60a5fa;
+    --accent-soft: rgba(96, 165, 250, 0.16);
+    --shadow: 0 20px 60px -40px rgba(15, 23, 42, 0.8);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: var(--font-family);
+    color: var(--text-primary);
+    background: radial-gradient(circle at top, rgba(255, 255, 255, 0.05), transparent 55%),
+                var(--page-background, #020617);
+    min-height: 100vh;
+    padding: clamp(2rem, 8vw, 4rem) clamp(1.5rem, 5vw, 4.5rem);
+    background-attachment: fixed;
+}
+
+body[data-theme="crm"] {
+    --accent: #38bdf8;
+    --accent-soft: rgba(56, 189, 248, 0.16);
+    --page-background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.24), transparent 55%), #020617;
+}
+
+body[data-theme="commerce"] {
+    --accent: #f97316;
+    --accent-soft: rgba(249, 115, 22, 0.16);
+    --page-background: radial-gradient(circle at top right, rgba(249, 115, 22, 0.25), transparent 60%), #0b1120;
+}
+
+body[data-theme="interactive"] {
+    --accent: #a855f7;
+    --accent-soft: rgba(168, 85, 247, 0.18);
+    --page-background: radial-gradient(circle at center, rgba(168, 85, 247, 0.25), transparent 60%), #080816;
+}
+
+body[data-theme="hospitality"] {
+    --accent: #22c55e;
+    --accent-soft: rgba(34, 197, 94, 0.18);
+    --page-background: radial-gradient(circle at top, rgba(34, 197, 94, 0.22), transparent 58%), #05130a;
+}
+
+a {
+    color: inherit;
+}
+
+header {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    margin-bottom: clamp(3rem, 8vw, 5rem);
+}
+
+.top-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    font-size: 0.75rem;
+    color: rgba(248, 250, 252, 0.6);
+}
+
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    text-decoration: none;
+    color: rgba(248, 250, 252, 0.75);
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    transition: color 0.25s ease, transform 0.25s ease;
+}
+
+.back-link svg {
+    width: 1rem;
+    height: 1rem;
+}
+
+.back-link:hover {
+    color: #fff;
+    transform: translateX(-2px);
+}
+
+.hero {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: clamp(2rem, 6vw, 4rem);
+    align-items: center;
+}
+
+.hero-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.45rem 1.15rem;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: rgba(15, 23, 42, 0.85);
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 1.5rem;
+}
+
+.hero h1 {
+    font-size: clamp(2.8rem, 5.5vw, 4.8rem);
+    letter-spacing: -0.03em;
+    margin-bottom: 1.2rem;
+}
+
+.hero p {
+    font-size: clamp(1.05rem, 2.2vw, 1.3rem);
+    line-height: 1.7;
+    color: var(--text-secondary);
+    margin-bottom: 2rem;
+}
+
+.hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1.5rem;
+}
+
+.stat-card {
+    padding: 1.75rem;
+    border-radius: 1.5rem;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    box-shadow: var(--shadow);
+}
+
+.stat-card span {
+    display: block;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.7rem;
+    color: rgba(248, 250, 252, 0.55);
+}
+
+.stat-card strong {
+    display: block;
+    margin-top: 0.9rem;
+    font-size: 1.85rem;
+}
+
+main {
+    display: grid;
+    gap: clamp(3rem, 7vw, 4.5rem);
+}
+
+.section {
+    display: grid;
+    gap: 1.75rem;
+}
+
+.section h2 {
+    font-size: clamp(2rem, 4vw, 3rem);
+    letter-spacing: -0.02em;
+}
+
+.section p.lead {
+    color: var(--text-secondary);
+    font-size: 1.05rem;
+    line-height: 1.7;
+}
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.feature-card {
+    padding: 1.75rem;
+    border-radius: 1.4rem;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    backdrop-filter: blur(12px);
+    display: grid;
+    gap: 1rem;
+}
+
+.feature-card h3 {
+    font-size: 1.2rem;
+}
+
+.feature-card p {
+    color: var(--text-secondary);
+    line-height: 1.6;
+    font-size: 0.98rem;
+}
+
+.list-grid {
+    display: grid;
+    gap: 1rem;
+}
+
+.list-grid li {
+    list-style: none;
+    padding: 1.1rem 1.5rem;
+    border-radius: 1.2rem;
+    border: 1px solid var(--border);
+    background: var(--surface-soft);
+    color: var(--text-secondary);
+    font-size: 0.98rem;
+}
+
+.callout {
+    padding: clamp(2rem, 5vw, 3rem);
+    border-radius: 1.75rem;
+    border: 1px solid var(--border);
+    background: rgba(15, 23, 42, 0.75);
+    display: grid;
+    gap: 1.25rem;
+    align-items: center;
+}
+
+.callout strong {
+    font-size: clamp(1.6rem, 3.5vw, 2.2rem);
+}
+
+.callout-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.button-primary,
+.button-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.85rem 1.8rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.button-primary {
+    background: #fff;
+    color: #0f172a;
+    box-shadow: 0 15px 40px -25px rgba(255, 255, 255, 0.9);
+}
+
+.button-primary:hover {
+    transform: translateY(-2px);
+}
+
+.button-secondary {
+    border: 1px solid rgba(248, 250, 252, 0.25);
+    background: rgba(248, 250, 252, 0.08);
+    color: #fff;
+}
+
+.button-secondary:hover {
+    background: rgba(248, 250, 252, 0.16);
+    transform: translateY(-2px);
+}
+
+footer {
+    margin-top: clamp(3rem, 6vw, 4.5rem);
+    font-size: 0.9rem;
+    color: rgba(248, 250, 252, 0.55);
+}
+
+@media (max-width: 720px) {
+    .top-bar {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    body {
+        padding: 2rem 1.25rem 3rem;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -3,228 +3,645 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Modern Three.js Site</title>
+    <title>YA1 Creative Studio – Portfolio</title>
     <style>
-        /* Reset default styles */
+        :root {
+            --background: #050609;
+            --foreground: #ffffff;
+            --muted: rgba(255, 255, 255, 0.65);
+            --accent: #60a5fa;
+            --accent-soft: rgba(96, 165, 250, 0.1);
+            --surface: rgba(12, 14, 20, 0.55);
+            --surface-strong: rgba(12, 14, 20, 0.8);
+            --border: rgba(255, 255, 255, 0.08);
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        }
+
         * {
             margin: 0;
             padding: 0;
             box-sizing: border-box;
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
         }
 
-        /* Canvas styling */
+        body {
+            background: var(--background);
+            color: var(--foreground);
+            min-height: 100vh;
+            overflow-x: hidden;
+        }
+
         #threejs-canvas {
             position: fixed;
-            top: 0;
-            left: 0;
+            inset: 0;
+            z-index: -2;
+        }
+
+        .overlay-gradient {
+            position: fixed;
+            inset: 0;
+            background: radial-gradient(circle at top, rgba(96, 165, 250, 0.22), transparent 55%),
+                        radial-gradient(circle at bottom, rgba(236, 72, 153, 0.18), transparent 50%);
             z-index: -1;
         }
 
-        /* Main content container */
         .content {
             position: relative;
-            padding: 2rem;
-            color: #ffffff;
+            padding: 2.5rem clamp(1.5rem, 4vw, 4rem) 4rem;
             min-height: 100vh;
             display: flex;
             flex-direction: column;
+            gap: 6rem;
         }
 
-        /* Navigation styling */
         nav {
             display: flex;
             justify-content: space-between;
             align-items: center;
-            padding: 1rem 0;
-            margin-bottom: 4rem;
+            gap: 2rem;
         }
 
         .logo {
-            font-size: 1.5rem;
+            font-size: 1.1rem;
             font-weight: 700;
-            letter-spacing: -0.5px;
+            letter-spacing: 0.35rem;
+            text-transform: uppercase;
         }
 
         .nav-links {
             display: flex;
-            gap: 2rem;
+            gap: clamp(1.5rem, 4vw, 3rem);
         }
 
         .nav-links a {
-            color: #ffffff;
+            color: var(--muted);
             text-decoration: none;
-            font-size: 1rem;
-            opacity: 0.8;
-            transition: opacity 0.3s ease;
+            font-size: 0.95rem;
+            letter-spacing: 0.05rem;
+            text-transform: uppercase;
+            transition: color 0.3s ease, opacity 0.3s ease;
         }
 
         .nav-links a:hover {
-            opacity: 1;
+            color: var(--foreground);
         }
 
-        /* Hero section styling */
         .hero {
-            max-width: 800px;
-            margin: auto;
-            text-align: center;
-            padding: 4rem 0;
+            margin-top: 4rem;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 3rem;
+            align-items: center;
         }
 
-        .hero h1 {
-            font-size: 4rem;
-            font-weight: 800;
-            line-height: 1.1;
+        .hero-copy h1 {
+            font-size: clamp(2.8rem, 6vw, 4.8rem);
+            line-height: 1.05;
+            letter-spacing: -0.04em;
             margin-bottom: 1.5rem;
-            letter-spacing: -1px;
         }
 
-        .hero p {
-            font-size: 1.25rem;
-            opacity: 0.8;
-            margin-bottom: 2rem;
-            line-height: 1.6;
+        .hero-copy p {
+            font-size: clamp(1.1rem, 2.4vw, 1.35rem);
+            color: var(--muted);
+            line-height: 1.65;
+            margin-bottom: 2.5rem;
         }
 
-        /* Button styling */
-        .cta-button {
-            display: inline-block;
-            padding: 1rem 2rem;
-            background: #ffffff;
-            color: #000000;
-            text-decoration: none;
-            border-radius: 50px;
+        .button-group {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+        }
+
+        .cta-button,
+        .ghost-button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.6rem;
+            padding: 0.85rem 1.8rem;
+            border-radius: 999px;
             font-weight: 600;
-            transition: transform 0.3s ease;
+            text-decoration: none;
+            transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+            letter-spacing: 0.02em;
+        }
+
+        .cta-button {
+            color: #000;
+            background: #fff;
+            box-shadow: 0 12px 30px -18px rgba(255, 255, 255, 0.8);
         }
 
         .cta-button:hover {
             transform: translateY(-2px);
+            box-shadow: 0 16px 40px -18px rgba(255, 255, 255, 0.75);
         }
 
-        /* Scroll indicator */
-        .scroll-indicator {
+        .ghost-button {
+            color: var(--foreground);
+            border: 1px solid var(--border);
+            background: rgba(255, 255, 255, 0.02);
+        }
+
+        .ghost-button:hover {
+            background: rgba(255, 255, 255, 0.08);
+            transform: translateY(-2px);
+        }
+
+        .metrics {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 1.5rem;
+        }
+
+        .metric-card {
+            padding: 1.5rem;
+            border-radius: 1.25rem;
+            background: var(--surface);
+            border: 1px solid var(--border);
+        }
+
+        .metric-card span {
+            display: block;
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--muted);
+        }
+
+        .metric-card strong {
+            display: block;
+            font-size: 2rem;
+            margin-top: 0.65rem;
+        }
+
+        .section-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            margin-bottom: 2.5rem;
+            gap: 2rem;
+        }
+
+        .section-header h2 {
+            font-size: clamp(2rem, 4vw, 3rem);
+            letter-spacing: -0.03em;
+        }
+
+        .section-header p {
+            color: var(--muted);
+            line-height: 1.6;
+            max-width: 520px;
+        }
+
+        .projects-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 2rem;
+        }
+
+        .project-card {
+            position: relative;
+            padding: 2.25rem;
+            border-radius: 1.75rem;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            backdrop-filter: blur(8px);
+            transition: transform 0.35s ease, border-color 0.35s ease, background 0.35s ease;
+            overflow: hidden;
+        }
+
+        .project-card::after {
+            content: "";
             position: absolute;
-            bottom: 2rem;
-            left: 50%;
-            transform: translateX(-50%);
-            opacity: 0.6;
-            animation: bounce 2s infinite;
+            inset: 0;
+            background: linear-gradient(135deg, rgba(96, 165, 250, 0.18), transparent 55%);
+            opacity: 0;
+            transition: opacity 0.35s ease;
         }
 
-        @keyframes bounce {
-            0%, 100% { transform: translateY(0); }
-            50% { transform: translateY(-10px); }
+        .project-card:hover {
+            transform: translateY(-6px);
+            border-color: rgba(96, 165, 250, 0.35);
         }
 
-        /* Loading screen */
+        .project-card:hover::after {
+            opacity: 1;
+        }
+
+        .project-tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.35rem 0.9rem;
+            border-radius: 999px;
+            background: rgba(96, 165, 250, 0.16);
+            color: rgba(255, 255, 255, 0.85);
+            font-size: 0.75rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            margin-bottom: 1.5rem;
+        }
+
+        .project-card h3 {
+            font-size: 1.45rem;
+            margin-bottom: 0.75rem;
+        }
+
+        .project-card p {
+            color: var(--muted);
+            line-height: 1.6;
+            margin-bottom: 1.5rem;
+        }
+
+        .project-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.6rem 1rem;
+            margin-bottom: 1.8rem;
+        }
+
+        .project-meta span {
+            font-size: 0.85rem;
+            color: rgba(255, 255, 255, 0.7);
+        }
+
+        .project-link {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            color: #fff;
+            text-decoration: none;
+            font-weight: 600;
+            z-index: 1;
+        }
+
+        .project-link svg {
+            width: 1.2rem;
+            height: 1.2rem;
+            transition: transform 0.25s ease;
+        }
+
+        .project-card:hover .project-link svg {
+            transform: translateX(4px);
+        }
+
+        .services-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+            gap: 1.75rem;
+        }
+
+        .service-card {
+            padding: 2rem;
+            border-radius: 1.5rem;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .service-card h3 {
+            font-size: 1.25rem;
+        }
+
+        .service-card ul {
+            list-style: none;
+            display: grid;
+            gap: 0.65rem;
+            color: var(--muted);
+            font-size: 0.95rem;
+        }
+
+        .service-card ul li::before {
+            content: "•";
+            margin-right: 0.65rem;
+            color: rgba(96, 165, 250, 0.85);
+        }
+
+        .contact-section {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 2rem;
+            align-items: center;
+        }
+
+        .contact-card {
+            padding: 2.5rem;
+            border-radius: 1.75rem;
+            background: var(--surface-strong);
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            display: grid;
+            gap: 1.25rem;
+        }
+
+        .contact-card span {
+            font-size: 0.9rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.6);
+        }
+
+        .contact-card a {
+            color: #fff;
+            font-size: 1.5rem;
+            text-decoration: none;
+        }
+
+        footer {
+            padding-top: 3rem;
+            border-top: 1px solid var(--border);
+            color: rgba(255, 255, 255, 0.55);
+            font-size: 0.9rem;
+        }
+
+        @media (max-width: 900px) {
+            .content {
+                padding-top: 2rem;
+            }
+
+            nav {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .nav-links {
+                flex-wrap: wrap;
+                gap: 1rem;
+            }
+        }
+
+        @media (max-width: 600px) {
+            .hero {
+                margin-top: 2rem;
+            }
+
+            .metrics {
+                grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="loading-screen" aria-hidden="true">Loading...</div>
+    <canvas id="threejs-canvas"></canvas>
+    <div class="overlay-gradient" aria-hidden="true"></div>
+
+    <div class="content">
+        <nav>
+            <div class="logo">YA1 CREATIVE</div>
+            <div class="nav-links">
+                <a href="#about">About</a>
+                <a href="#work">Work</a>
+                <a href="#services">Services</a>
+                <a href="#contact">Contact</a>
+            </div>
+        </nav>
+
+        <section class="hero" id="about">
+            <div class="hero-copy">
+                <h1>Product-grade experiences for modern brands.</h1>
+                <p>I design and build immersive web applications that feel human, run fast, and solve real business problems. Explore a curated set of live CRM, ecommerce, and experiential projects tailored for Los Angeles teams.</p>
+                <div class="button-group">
+                    <a class="cta-button" href="#work">View Signature Projects</a>
+                    <a class="ghost-button" href="#contact">Schedule a Discovery Call</a>
+                </div>
+            </div>
+            <div class="metrics">
+                <div class="metric-card">
+                    <span>Industries Served</span>
+                    <strong>10+</strong>
+                </div>
+                <div class="metric-card">
+                    <span>Experience</span>
+                    <strong>8 yrs</strong>
+                </div>
+                <div class="metric-card">
+                    <span>Avg. Conversion Lift</span>
+                    <strong>32%</strong>
+                </div>
+            </div>
+        </section>
+
+        <section id="work">
+            <div class="section-header">
+                <h2>Signature project playbooks</h2>
+                <p>Each concept is production-ready, built with maintainable code, clean UX, and a focus on measurable business outcomes. Dive into the live demos to experience the flows in detail.</p>
+            </div>
+            <div class="projects-grid">
+                <article class="project-card">
+                    <div class="project-tag">CRM Platform</div>
+                    <h3>Latitude CRM – Unified Client Intelligence</h3>
+                    <p>End-to-end CRM designed for boutique agencies. Includes pipeline forecasting, sentiment-driven alerts, and automation hand-offs powered by custom AI copilots.</p>
+                    <div class="project-meta">
+                        <span>Product Strategy</span>
+                        <span>Next.js · Supabase · Tailwind</span>
+                    </div>
+                    <a class="project-link" href="projects/latitude-crm.html">Explore the experience
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M5 12h14"></path>
+                            <path d="M13 6l6 6-6 6"></path>
+                        </svg>
+                    </a>
+                </article>
+
+                <article class="project-card">
+                    <div class="project-tag">Ecommerce</div>
+                    <h3>Halo Haus – Immersive Lifestyle Retail</h3>
+                    <p>A conversion-first ecommerce flow with cinematic merchandising, guided bundling, and a polished checkout that syncs with Shopify Plus and Klaviyo marketing loops.</p>
+                    <div class="project-meta">
+                        <span>Experience Design</span>
+                        <span>Remix · Shopify Hydrogen · Sanity</span>
+                    </div>
+                    <a class="project-link" href="projects/halo-haus.html">View storefront concept
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M5 12h14"></path>
+                            <path d="M13 6l6 6-6 6"></path>
+                        </svg>
+                    </a>
+                </article>
+
+                <article class="project-card">
+                    <div class="project-tag">Interactive Showcase</div>
+                    <h3>PulseFrame – Animated Product Stories</h3>
+                    <p>Interactive 2D/3D storytelling engine for launch campaigns. Layered scroll choreography, WebGL particles, and collaborative storyboards for art directors.</p>
+                    <div class="project-meta">
+                        <span>Motion Systems</span>
+                        <span>Three.js · GSAP · Web Audio API</span>
+                    </div>
+                    <a class="project-link" href="projects/pulseframe.html">Launch interactive preview
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M5 12h14"></path>
+                            <path d="M13 6l6 6-6 6"></path>
+                        </svg>
+                    </a>
+                </article>
+
+                <article class="project-card">
+                    <div class="project-tag">Hospitality Growth</div>
+                    <h3>MenuLoop – QR-led Guest Engagement</h3>
+                    <p>QR-first ordering and loyalty for LA restaurants. Guests scan, browse animated menus, and earn perks while managers monitor real-time inventory and staff pacing.</p>
+                    <div class="project-meta">
+                        <span>Product Design</span>
+                        <span>Vue · Firebase · Stripe Terminal</span>
+                    </div>
+                    <a class="project-link" href="projects/menuloop.html">See restaurant system
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M5 12h14"></path>
+                            <path d="M13 6l6 6-6 6"></path>
+                        </svg>
+                    </a>
+                </article>
+            </div>
+        </section>
+
+        <section id="services">
+            <div class="section-header">
+                <h2>From discovery to launch</h2>
+                <p>A structured process keeps every build grounded in business outcomes and measurable KPIs. I stay close to your team to ship fast and iterate even faster.</p>
+            </div>
+            <div class="services-grid">
+                <div class="service-card">
+                    <h3>Product &amp; UX Strategy</h3>
+                    <ul>
+                        <li>Customer journey mapping workshops</li>
+                        <li>Jobs-to-be-done research sprints</li>
+                        <li>Analytics &amp; instrumentation planning</li>
+                    </ul>
+                </div>
+                <div class="service-card">
+                    <h3>Full-stack Development</h3>
+                    <ul>
+                        <li>React, Vue, and native WebGL builds</li>
+                        <li>High-performance data visualizations</li>
+                        <li>API design, authentication, and ops</li>
+                    </ul>
+                </div>
+                <div class="service-card">
+                    <h3>Growth &amp; Optimization</h3>
+                    <ul>
+                        <li>Experiment frameworks &amp; CRO setup</li>
+                        <li>Lifecycle automation and CRM flows</li>
+                        <li>Ongoing A/B testing &amp; performance tuning</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="contact" class="contact-section">
+            <div class="contact-card">
+                <span>Let’s build the next launch</span>
+                <h2>Tell me about the product you’re ready to ship.</h2>
+                <p style="color: var(--muted); line-height: 1.6;">I typically partner with marketing, product, and innovation teams across Los Angeles to deliver launches in 4–8 weeks. Share your goals and I’ll send over a tailored roadmap.</p>
+                <a href="mailto:hello@ya1creative.com">hello@ya1creative.com</a>
+                <a class="ghost-button" href="https://cal.com" target="_blank" rel="noopener">Book a 30-min call</a>
+            </div>
+            <div class="contact-card" style="background: rgba(96, 165, 250, 0.12); color: #0f172a;">
+                <span style="color: rgba(15, 23, 42, 0.6);">Capabilities Snapshot</span>
+                <ul style="list-style: none; color: rgba(15, 23, 42, 0.8); display: grid; gap: 0.75rem; font-size: 0.95rem;">
+                    <li>• WebGL &amp; motion design systems</li>
+                    <li>• CRM &amp; revenue intelligence dashboards</li>
+                    <li>• Shopify &amp; custom commerce integrations</li>
+                    <li>• Hospitality loyalty + QR ordering programs</li>
+                    <li>• Fractional product leadership engagements</li>
+                </ul>
+            </div>
+        </section>
+
+        <footer>
+            © <span id="year"></span> YA1 Creative Studio · Based in Los Angeles · Available for select collaborations.
+        </footer>
+    </div>
+
+    <script async src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script>
+        const yearSpan = document.getElementById('year');
+        if (yearSpan) {
+            yearSpan.textContent = new Date().getFullYear();
+        }
+
+        const loadingScreen = document.querySelector('.loading-screen');
+        window.addEventListener('load', () => {
+            if (loadingScreen) {
+                loadingScreen.classList.add('hidden');
+            }
+        });
+
+        // Initialize Three.js scene once script loads
+        window.addEventListener('load', () => {
+            if (typeof THREE === 'undefined') return;
+
+            const scene = new THREE.Scene();
+            const camera = new THREE.PerspectiveCamera(65, window.innerWidth / window.innerHeight, 0.1, 1000);
+            const renderer = new THREE.WebGLRenderer({
+                canvas: document.querySelector('#threejs-canvas'),
+                antialias: true,
+                alpha: true
+            });
+
+            renderer.setSize(window.innerWidth, window.innerHeight);
+            renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+            const geometry = new THREE.IcosahedronGeometry(12, 1);
+            const material = new THREE.MeshStandardMaterial({
+                color: 0x4f46e5,
+                metalness: 0.4,
+                roughness: 0.2,
+                emissive: 0x0f172a,
+                emissiveIntensity: 0.6,
+                wireframe: false
+            });
+
+            const mesh = new THREE.Mesh(geometry, material);
+            scene.add(mesh);
+
+            const ambient = new THREE.AmbientLight(0xffffff, 0.35);
+            scene.add(ambient);
+
+            const pointLight = new THREE.PointLight(0x60a5fa, 1.2, 150);
+            pointLight.position.set(15, 20, 25);
+            scene.add(pointLight);
+
+            camera.position.z = 40;
+
+            function animate() {
+                requestAnimationFrame(animate);
+                mesh.rotation.x += 0.0025;
+                mesh.rotation.y += 0.0035;
+                renderer.render(scene, camera);
+            }
+
+            animate();
+
+            window.addEventListener('resize', () => {
+                camera.aspect = window.innerWidth / window.innerHeight;
+                camera.updateProjectionMatrix();
+                renderer.setSize(window.innerWidth, window.innerHeight);
+            });
+        });
+    </script>
+    <style>
         .loading-screen {
             position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: #000000;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            z-index: 1000;
-            transition: opacity 0.5s ease;
+            inset: 0;
+            display: grid;
+            place-items: center;
+            background: rgba(5, 6, 9, 0.92);
+            color: var(--muted);
+            letter-spacing: 0.2em;
+            text-transform: uppercase;
+            font-size: 0.85rem;
+            z-index: 10;
+            transition: opacity 0.45s ease;
         }
 
         .loading-screen.hidden {
             opacity: 0;
             pointer-events: none;
         }
-
-        /* Responsive design */
-        @media (max-width: 768px) {
-            .hero h1 {
-                font-size: 3rem;
-            }
-
-            .nav-links {
-                display: none;
-            }
-        }
     </style>
-</head>
-<body>
-    <!-- Loading screen -->
-    <div class="loading-screen">
-        <span>Loading...</span>
-    </div>
-
-    <!-- Three.js canvas -->
-    <canvas id="threejs-canvas"></canvas>
-
-    <!-- Main content -->
-    <div class="content">
-        <nav>
-            <div class="logo">LOGO</div>
-            <div class="nav-links">
-                <a href="#about">About</a>
-                <a href="#work">Work</a>
-                <a href="#contact">Contact</a>
-            </div>
-        </nav>
-
-        <section class="hero">
-            <h1>Create Something Amazing</h1>
-            <p>Transform your ideas into reality with cutting-edge 3D web experiences.</p>
-            <a href="#" class="cta-button">Get Started</a>
-        </section>
-
-        <div class="scroll-indicator">↓</div>
-    </div>
-
-    <!-- Three.js and main script -->
-    <script async src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-    <script>
-        // Wait for Three.js to load
-        window.addEventListener('load', () => {
-            // Initialize Three.js scene
-            const scene = new THREE.Scene();
-            const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
-            const renderer = new THREE.WebGLRenderer({
-                canvas: document.querySelector('#threejs-canvas'),
-                antialias: true
-            });
-
-            // Set renderer size
-            renderer.setSize(window.innerWidth, window.innerHeight);
-            renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-
-            // Add a simple mesh (customize this based on your needs)
-            const geometry = new THREE.TorusKnotGeometry(10, 3, 100, 16);
-            const material = new THREE.MeshNormalMaterial();
-            const torusKnot = new THREE.Mesh(geometry, material);
-            scene.add(torusKnot);
-
-            // Position camera
-            camera.position.z = 30;
-
-            // Animation loop
-            function animate() {
-                requestAnimationFrame(animate);
-                torusKnot.rotation.x += 0.01;
-                torusKnot.rotation.y += 0.01;
-                renderer.render(scene, camera);
-            }
-
-            // Handle window resize
-            window.addEventListener('resize', () => {
-                camera.aspect = window.innerWidth / window.innerHeight;
-                camera.updateProjectionMatrix();
-                renderer.setSize(window.innerWidth, window.innerHeight);
-            });
-
-            // Remove loading screen
-            document.querySelector('.loading-screen').classList.add('hidden');
-
-            // Start animation
-            animate();
-        });
-    </script>
 </body>
 </html>

--- a/projects/halo-haus.html
+++ b/projects/halo-haus.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Halo Haus – Immersive Lifestyle Retail</title>
+    <link rel="stylesheet" href="../css/projects.css">
+</head>
+<body data-theme="commerce">
+    <header>
+        <div class="top-bar">
+            <a class="back-link" href="../index.html">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/><path d="M9 12h12"/></svg>
+                Back to portfolio
+            </a>
+            <span>Halo Haus &bull; Direct-to-consumer retail experience</span>
+        </div>
+        <div class="hero">
+            <div>
+                <span class="hero-badge">Ecommerce / Retail Innovation</span>
+                <h1>Halo Haus blends cinematic merchandising with high-converting checkout flows.</h1>
+                <p>The concept reimagines ecommerce as a guided showroom—immersive product reveals, dynamic bundling, and storytelling modules that lift lifetime value while staying tightly integrated with Shopify Plus.</p>
+                <div class="callout-actions">
+                    <a class="button-primary" href="#journey">Explore customer journey</a>
+                    <a class="button-secondary" href="mailto:hello@ya1creative.com?subject=Halo%20Haus">Discuss a launch</a>
+                </div>
+            </div>
+            <div class="hero-stats">
+                <div class="stat-card">
+                    <span>Avg order value</span>
+                    <strong>+27%</strong>
+                </div>
+                <div class="stat-card">
+                    <span>Checkout speed</span>
+                    <strong>3 steps</strong>
+                </div>
+                <div class="stat-card">
+                    <span>Implementation</span>
+                    <strong>5 weeks</strong>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="section" id="journey">
+            <h2>Signature customer journey</h2>
+            <p class="lead">We combine editorial storytelling with data-backed merchandising to deliver a cart that feels personal, not transactional.</p>
+            <div class="feature-grid">
+                <article class="feature-card">
+                    <h3>Guided Storytelling</h3>
+                    <p>Scroll-triggered scenes reveal textures, materials, and brand rituals. Customers can pause to explore shoppable hotspots or add bundles curated for their goals.</p>
+                </article>
+                <article class="feature-card">
+                    <h3>Adaptive Bundling</h3>
+                    <p>AI-assisted bundler learns from customer behavior and inventory. Upsells stay contextually relevant and increase AOV without overwhelming the shopper.</p>
+                </article>
+                <article class="feature-card">
+                    <h3>Checkout Harmony</h3>
+                    <p>Headless checkout runs through Shopify Payments, Apple Pay, or Shop Pay. Order status pages include embedded care guides and loyalty enrollment.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section">
+            <h2>Stack + integrations</h2>
+            <ul class="list-grid">
+                <li>Remix + Shopify Hydrogen for blazing-fast React storefronts.</li>
+                <li>Sanity CMS orchestrating editorial content, bundles, and localization.</li>
+                <li>Algolia search with visual merchandising and semantic discovery.</li>
+                <li>Klaviyo + Postscript to automate lifecycle messaging and SMS drops.</li>
+                <li>Segment + GA4 instrumentation for granular attribution insights.</li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2>What shoppers experience</h2>
+            <p class="lead">The Halo Haus experience keeps customers inspired post-purchase and fuels retention.</p>
+            <ul class="list-grid">
+                <li>Onboarding quiz aligns product curation to wellness goals in under 60 seconds.</li>
+                <li>AR try-on previews allow shoppers to visualize hero products inside their space.</li>
+                <li>Loyalty wallet unlocks perks, restock reminders, and community events.</li>
+            </ul>
+        </section>
+
+        <section class="callout">
+            <strong>Launch a flagship storefront customers remember.</strong>
+            <p style="color: var(--text-secondary); line-height: 1.6;">Let’s tailor this system to your catalog and marketing stack. We’ll collaborate on merchandising strategy, conversion optimization, and creative direction.</p>
+            <div class="callout-actions">
+                <a class="button-primary" href="mailto:hello@ya1creative.com?subject=Halo%20Haus%20Discovery">Start a discovery sprint</a>
+                <a class="button-secondary" href="https://cal.com" target="_blank" rel="noopener">Book demo</a>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        © <span id="year"></span> YA1 Creative Studio. Halo Haus ecommerce framework for lifestyle brands.
+    </footer>
+
+    <script>
+        document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/projects/latitude-crm.html
+++ b/projects/latitude-crm.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Latitude CRM – Unified Client Intelligence</title>
+    <link rel="stylesheet" href="../css/projects.css">
+</head>
+<body data-theme="crm">
+    <header>
+        <div class="top-bar">
+            <a class="back-link" href="../index.html">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/><path d="M9 12h12"/></svg>
+                Back to portfolio
+            </a>
+            <span>Latitude CRM &bull; Revenue intelligence platform</span>
+        </div>
+        <div class="hero">
+            <div>
+                <span class="hero-badge">CRM / Client Success</span>
+                <h1>Latitude CRM unites pipeline health, client sentiment, and revenue forecasting.</h1>
+                <p>Purpose-built for boutique creative and marketing studios that juggle dozens of stakeholders. Latitude aligns sales, accounts, and operations with live dashboards, predictive insights, and human-centric workflows.</p>
+                <div class="callout-actions">
+                    <a class="button-primary" href="#prototype">View experience blueprint</a>
+                    <a class="button-secondary" href="mailto:hello@ya1creative.com?subject=Latitude%20CRM">Schedule a walkthrough</a>
+                </div>
+            </div>
+            <div class="hero-stats">
+                <div class="stat-card">
+                    <span>Time to deploy</span>
+                    <strong>6 weeks</strong>
+                </div>
+                <div class="stat-card">
+                    <span>Retention lift</span>
+                    <strong>+18%</strong>
+                </div>
+                <div class="stat-card">
+                    <span>Team adoption</span>
+                    <strong>92%</strong>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="section" id="prototype">
+            <h2>Experience blueprint</h2>
+            <p class="lead">The platform blends structured CRM workflows with intelligent nudges that help account teams take the right action at the right time. Every panel is intentionally crafted to reduce noise and surface actionable signals.</p>
+            <div class="feature-grid">
+                <article class="feature-card">
+                    <h3>Command Center</h3>
+                    <p>Omnichannel pipeline dashboard with weighted forecasting, stage velocity metrics, and cross-team workload visibility. Tailored alerts highlight deals that need attention based on sentiment and activity recency.</p>
+                </article>
+                <article class="feature-card">
+                    <h3>Client Pulse AI</h3>
+                    <p>Natural-language sentiment scoring ingests meeting transcripts and email threads to flag risk and upsell opportunities. Suggested next steps generate in-app tasks or push to Slack, Asana, or Notion.</p>
+                </article>
+                <article class="feature-card">
+                    <h3>Revenue Studio</h3>
+                    <p>Scenario planning with drag-and-drop forecasting, budget allocation, and staffing recommendations. Finance teams export snapshots directly into Airtable or Google Sheets with live formulas intact.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section">
+            <h2>Technology stack</h2>
+            <ul class="list-grid">
+                <li>Next.js 14 with React Server Components for ultra-responsive dashboards.</li>
+                <li>Supabase Postgres + Row Level Security powering multi-tenant data segregation.</li>
+                <li>tRPC microservices with background jobs handled by Inngest and Temporal.</li>
+                <li>OpenAI Assistants API for contextual coaching and sentiment analysis.</li>
+                <li>Segment + Metabase for analytics pipelines and stakeholder reporting.</li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2>Outcome highlights</h2>
+            <p class="lead">Latitude CRM is already driving results for studio clients piloting the system:</p>
+            <ul class="list-grid">
+                <li>Sales teams reduced weekly status meetings by 42% thanks to asynchronous deal recaps.</li>
+                <li>Account managers resolved at-risk engagements 2.4× faster with proactive sentiment alerts.</li>
+                <li>Leadership gained a unified forecast view consolidating HubSpot, QuickBooks, and Notion data.</li>
+            </ul>
+        </section>
+
+        <section class="callout">
+            <strong>Ready to deploy Latitude inside your studio?</strong>
+            <p style="color: var(--text-secondary); line-height: 1.6;">I’ll adapt the workflows to match your current CRM, import legacy data, and integrate with the tools your teams already trust. Pilot programs typically go live in six weeks.</p>
+            <div class="callout-actions">
+                <a class="button-primary" href="mailto:hello@ya1creative.com?subject=Latitude%20CRM%20Pilot">Start a pilot</a>
+                <a class="button-secondary" href="https://cal.com" target="_blank" rel="noopener">Book strategy session</a>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        © <span id="year"></span> YA1 Creative Studio. Latitude CRM concept crafted for high-touch agencies.
+    </footer>
+
+    <script>
+        document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/projects/menuloop.html
+++ b/projects/menuloop.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MenuLoop – QR-led Guest Engagement</title>
+    <link rel="stylesheet" href="../css/projects.css">
+</head>
+<body data-theme="hospitality">
+    <header>
+        <div class="top-bar">
+            <a class="back-link" href="../index.html">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/><path d="M9 12h12"/></svg>
+                Back to portfolio
+            </a>
+            <span>MenuLoop &bull; Hospitality growth platform</span>
+        </div>
+        <div class="hero">
+            <div>
+                <span class="hero-badge">Hospitality / QR Commerce</span>
+                <h1>MenuLoop transforms QR menus into loyalty-powered guest experiences.</h1>
+                <p>Built for Los Angeles restaurants, MenuLoop merges digital ordering, loyalty, and real-time operations dashboards. Guests love the fluid UI, while operators gain live insights into table pacing, menu performance, and staffing.</p>
+                <div class="callout-actions">
+                    <a class="button-primary" href="#guest">Review guest journey</a>
+                    <a class="button-secondary" href="mailto:hello@ya1creative.com?subject=MenuLoop">Partner with MenuLoop</a>
+                </div>
+            </div>
+            <div class="hero-stats">
+                <div class="stat-card">
+                    <span>Check size lift</span>
+                    <strong>+19%</strong>
+                </div>
+                <div class="stat-card">
+                    <span>Loyalty opt-in</span>
+                    <strong>72%</strong>
+                </div>
+                <div class="stat-card">
+                    <span>Rollout time</span>
+                    <strong>4 weeks</strong>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="section" id="guest">
+            <h2>Guest-first ordering</h2>
+            <p class="lead">A warm, polished interface that keeps guests engaged from the first scan to the final tip.</p>
+            <div class="feature-grid">
+                <article class="feature-card">
+                    <h3>Dynamic Menus</h3>
+                    <p>Motion-enhanced categories, dietary filters, and seasonal spotlights. Guests add to a shared table cart while seeing chef notes and wine pairings.</p>
+                </article>
+                <article class="feature-card">
+                    <h3>Loyalty Wallet</h3>
+                    <p>Contactless signup with instant rewards, visit streaks, and surprise drops. POS-sync keeps rewards accurate across dine-in, takeout, and delivery.</p>
+                </article>
+                <article class="feature-card">
+                    <h3>Instant Feedback</h3>
+                    <p>Micro-surveys triggered post-payment surface guest sentiment for each menu item, helping chefs iterate faster.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section">
+            <h2>Operator cockpit</h2>
+            <ul class="list-grid">
+                <li>Vue 3 + Vite dashboard with occupancy heatmaps and pacing alerts.</li>
+                <li>Firebase Firestore for live orders, staff messaging, and offline sync.</li>
+                <li>Stripe Terminal + Tap to Pay for tableside payments and tip workflows.</li>
+                <li>Toast POS + SevenRooms integrations to streamline loyalty and reservations.</li>
+                <li>Zapier and Make automations to trigger marketing campaigns and re-engagement.</li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2>Impact for LA venues</h2>
+            <p class="lead">MenuLoop is tuned for multi-location hospitality groups balancing premium service with volume.</p>
+            <ul class="list-grid">
+                <li>Average table turn reduced by 12 minutes through QR ordering and pacing insights.</li>
+                <li>Marketing teams capture 3× more guest emails and SMS opt-ins at point-of-sale.</li>
+                <li>Managers forecast staff needs with predictive analytics fed by historical demand and local events.</li>
+            </ul>
+        </section>
+
+        <section class="callout">
+            <strong>Spin up MenuLoop across your venues.</strong>
+            <p style="color: var(--text-secondary); line-height: 1.6;">We’ll align with your existing POS stack, train staff, and launch targeted loyalty campaigns that keep guests returning weekly.</p>
+            <div class="callout-actions">
+                <a class="button-primary" href="mailto:hello@ya1creative.com?subject=MenuLoop%20Rollout">Schedule rollout plan</a>
+                <a class="button-secondary" href="https://cal.com" target="_blank" rel="noopener">Book operator session</a>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        © <span id="year"></span> YA1 Creative Studio. MenuLoop hospitality engagement platform.
+    </footer>
+
+    <script>
+        document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/projects/pulseframe.html
+++ b/projects/pulseframe.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PulseFrame – Animated Product Stories</title>
+    <link rel="stylesheet" href="../css/projects.css">
+</head>
+<body data-theme="interactive">
+    <header>
+        <div class="top-bar">
+            <a class="back-link" href="../index.html">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/><path d="M9 12h12"/></svg>
+                Back to portfolio
+            </a>
+            <span>PulseFrame &bull; Experiential campaign engine</span>
+        </div>
+        <div class="hero">
+            <div>
+                <span class="hero-badge">Interactive / Motion</span>
+                <h1>PulseFrame choreographs 2D motion, audio, and WebGL storytelling for launches that move people.</h1>
+                <p>This toolkit empowers creative teams to prototype and ship immersive campaign sites. Designers control every beat—layering scroll-driven animation, synchronized audio, and real-time collaboration tools.</p>
+                <div class="callout-actions">
+                    <a class="button-primary" href="#timeline">See flow modules</a>
+                    <a class="button-secondary" href="mailto:hello@ya1creative.com?subject=PulseFrame">Request live demo</a>
+                </div>
+            </div>
+            <div class="hero-stats">
+                <div class="stat-card">
+                    <span>Scene editor</span>
+                    <strong>Browser-based</strong>
+                </div>
+                <div class="stat-card">
+                    <span>Frame rate</span>
+                    <strong>60 FPS</strong>
+                </div>
+                <div class="stat-card">
+                    <span>Collaboration</span>
+                    <strong>Live cursors</strong>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="section" id="timeline">
+            <h2>Modular storytelling flow</h2>
+            <p class="lead">PulseFrame breaks complex animation into approachable modules that teams remix without writing code.</p>
+            <div class="feature-grid">
+                <article class="feature-card">
+                    <h3>Scene Blocks</h3>
+                    <p>Pre-built hero scenes and visualizers that snap together. Each block supports live texture swaps, typography controls, and gradient overlays for brand alignment.</p>
+                </article>
+                <article class="feature-card">
+                    <h3>Scroll Sync Engine</h3>
+                    <p>GSAP + Three.js choreography ties animation progress to scroll velocity for buttery transitions on desktop and mobile.</p>
+                </article>
+                <article class="feature-card">
+                    <h3>Audio Director</h3>
+                    <p>Spatial audio tools match sound design with scene timing. Producers manage fades, loops, and call-to-action cues directly inside the browser editor.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section">
+            <h2>Production toolkit</h2>
+            <ul class="list-grid">
+                <li>Real-time Figma sync pipes updated visuals straight into the prototype.</li>
+                <li>Contentful CMS manages copy, subtitles, and localization across scenes.</li>
+                <li>Netlify Edge functions handle personalization and runtime A/B testing.</li>
+                <li>Mixpanel + Vercel Analytics monitor engagement hotspots and bounce patterns.</li>
+                <li>Automatic accessibility checks ensure motion preferences and reduced motion support.</li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2>Launch impact</h2>
+            <p class="lead">Studios use PulseFrame to transform product drops into memorable moments.</p>
+            <ul class="list-grid">
+                <li>Cut asset production time by 35% via collaborative scene editor and shared animation presets.</li>
+                <li>Increased landing page watch-through rates by 54% with synchronized audio cues.</li>
+                <li>Achieved sub-2 second LCP with finely tuned WebGL optimizations and lazy-loaded sequences.</li>
+            </ul>
+        </section>
+
+        <section class="callout">
+            <strong>Bring PulseFrame to your next launch film.</strong>
+            <p style="color: var(--text-secondary); line-height: 1.6;">Whether it’s a feature announcement or an immersive product story, I’ll embed with your team to script the journey, design the visuals, and build the real-time experience.</p>
+            <div class="callout-actions">
+                <a class="button-primary" href="mailto:hello@ya1creative.com?subject=PulseFrame%20Project">Start a project</a>
+                <a class="button-secondary" href="https://cal.com" target="_blank" rel="noopener">Reserve a slot</a>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        © <span id="year"></span> YA1 Creative Studio. PulseFrame interactive storytelling engine.
+    </footer>
+
+    <script>
+        document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- redesign the landing page with detailed sections for signature work, services, and contact
- add dedicated project pages for CRM, ecommerce, interactive campaign, and hospitality QR concepts
- introduce shared styling for project showcases with tailored themes per concept

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_b_68d4e163fac8832487cf1c0bdebe3676